### PR TITLE
chore: release 2025.01.19

### DIFF
--- a/500px/deno.json
+++ b/500px/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tugrulates/500px",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": "./mod.ts",
   "tasks": {
     "compile": "deno compile -N=api.500px.com --no-prompt --include=graphql -o=../dist/ mod.ts"

--- a/Releases.md
+++ b/Releases.md
@@ -1,3 +1,44 @@
+### 2025.01.19
+
+#### @tugrulates/500px 0.1.2 (patch)
+
+- chore(*): merge all deps at the root (#66)
+- chore(*): isolate dependencies (#63)
+
+#### @tugrulates/duolingo 0.1.2 (patch)
+
+- fix(duolingo)!: undefined for missing league (#59)
+- fix(duolingo): graceful report of unstarted league (#49)
+
+#### @tugrulates/internal 0.1.3 (patch)
+
+- chore(*): merge all deps at the root (#66)
+- chore(*): isolate dependencies (#63)
+
+#### @tugrulates/lonely-planet 0.1.2 (patch)
+
+- feat(lonely-planet): configless client (#48)
+- fix(lonely-planet): fix response parsing (#47)
+- refactor(lonely-planet,testing,photos): explicit test names (#56)
+- test(lonely-planet): add unit tests (#55)
+
+#### @tugrulates/photos 0.1.5 (patch)
+
+- fix(photos): fix exiftool for Deno 2.1.6 (#52)
+- fix(photos): fix failure when system doesn't have exiftool (#46)
+- fix(photos): fix exiftool process leak (#44)
+- refactor(lonely-planet,testing,photos): explicit test names (#56)
+- test(photos): cli test (#65)
+- test(photos): add unittests (#45)
+
+#### @tugrulates/testing 0.1.0 (minor)
+
+- feat(testing): mock console (#64)
+- feat(testing): effortless fetch mock (#53)
+- fix(testing): improved error messages for mock fetch (#62)
+- fix(testing): use request method in matching mock calls (#61)
+- refactor(lonely-planet,testing,photos): explicit test names (#56)
+
 ### 2025.01.11
 
 #### @tugrulates/500px 0.1.1 (patch)

--- a/duolingo/deno.json
+++ b/duolingo/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tugrulates/duolingo",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": "./mod.ts",
   "tasks": {
     "compile": "deno compile -R=$HOME/.scripts -W=$HOME/.scripts -E=HOME -N=www.duolingo.com --unstable-kv --no-prompt -o=../dist/ mod.ts"

--- a/internal/deno.json
+++ b/internal/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tugrulates/internal",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "exports": {
     "./async": "./async.ts",
     "./cli": "./cli.ts",

--- a/lonely-planet/deno.json
+++ b/lonely-planet/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tugrulates/lonely-planet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "exports": "./mod.ts",
   "tasks": {
     "compile": "deno compile -R=$HOME/.scripts -W=$HOME/.scripts -E=HOME -N --unstable-kv --no-prompt -o=../dist/ mod.ts"

--- a/photos/deno.json
+++ b/photos/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tugrulates/photos",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "exports": "./mod.ts",
   "tasks": {
     "compile": "deno compile -A -o=../dist/ mod.ts"


### PR DESCRIPTION
The following updates are detected:

| module   | from    | to      | type  |
|----------|---------|---------|-------|
|@tugrulates/500px|0.1.1|0.1.2|patch|
|duolingo|0.1.1|0.1.2|patch|
|@tugrulates/internal|0.1.2|0.1.3|patch|
|lonely-planet|0.1.1|0.1.2|patch|
|photos|0.1.4|0.1.5|patch|
|testing|0.0.0|0.1.0|minor|

Please ensure:
- [ ] Versions in deno.json files are updated correctly
- [ ] Releases.md is updated correctly







The following commits are ignored:

- [refactor: rename test files to match tested files (#60)](/tugrulates/libs/commit/6c92a296030103289364d7d78a623818629b5681)
- [style: disallow null assertion (#58)](/tugrulates/libs/commit/b93e1e807d9a2a975c922564caeda4e6130a2d45)
- [refactor: cleanup some usages of null (#57)](/tugrulates/libs/commit/da7f55148f990c5fb7ef628502ea39f0f7d60623)
- [ci: add testing package (#54)](/tugrulates/libs/commit/034bda9c0c37c6f994bbec131d11da7d3ecc5686)
- [docs: update readme with repo name change (#50)](/tugrulates/libs/commit/5328984bc9fd55e7c3e81cc6a6809239e5021dca)
- [chore: log initial release (#43)](/tugrulates/libs/commit/f59e44d4d9e2d7ecd1177890062f9ef3695c8e67)

---

To make edits to this PR:

```sh
git fetch upstream release-2025-01-19-22-21-41 && git checkout -b release-2025-01-19-22-21-41 upstream/release-2025-01-19-22-21-41
```
